### PR TITLE
Work around GO15VENDOREXPERIMENT for Go 1.5

### DIFF
--- a/package15.go
+++ b/package15.go
@@ -1,0 +1,7 @@
+// +build !go1.6
+
+package main
+
+import "os"
+
+var useVendor = os.Getenv("GO15VENDOREXPERIMENT") == "1"

--- a/package16.go
+++ b/package16.go
@@ -1,0 +1,7 @@
+// +build go1.6
+
+package main
+
+import "os"
+
+var useVendor = os.Getenv("GO15VENDOREXPERIMENT") == "0" || os.Getenv("GO15VENDOREXPERIMENT") == ""


### PR DESCRIPTION
r? @dtbartle 

The code to support `GO15VENDOREXPERIMENT` is in the Go 1.6 `go/build` package, but not the Go 1.5 one, so we have to implement a custom package finder to support vendor directories.

Spec is here: https://docs.google.com/document/d/1Bz5-UB7g2uPBdOx-rw5t9MxJwkfpx90cqG9AFL0JAYo/edit?pref=2&pli=1